### PR TITLE
Instil sanity with Nix dev support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,304 @@
+{
+  "nodes": {
+    "attic": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1738524606,
+        "narHash": "sha256-hPYEJ4juK3ph7kbjbvv7PlU1D9pAkkhl+pwx8fZY53U=",
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "rev": "ff8a897d1f4408ebbf4d45fa9049c06b3e1e3f4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "rev": "ff8a897d1f4408ebbf4d45fa9049c06b3e1e3f4e",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722960479,
+        "narHash": "sha256-NhCkJJQhD5GUib8zN9JrmYGMwt4lCRp6ZVNzIiYCl0Y=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "4c6c77920b8d44cd6660c1621dea6b3fc4b4c4f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1740485968,
+        "narHash": "sha256-WK+PZHbfDjLyveXAxpnrfagiFgZWaTJglewBWniTn2Y=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "19c1140419c4f1cdf88ad4c1cfb6605597628940",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "19c1140419c4f1cdf88ad4c1cfb6605597628940",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "northwood-nixpkgs",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741701235,
+        "narHash": "sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3+91651y3Sqo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "c630dfa8abcc65984cc1e47fb25d4552c81dd37e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1734083684,
+        "narHash": "sha256-5fNndbndxSx5d+C/D0p/VF32xDiJCJzyOqorOYW4JEo=",
+        "type": "tarball",
+        "url": "https://github.com/nixos/nixpkgs/archive/314e12ba369ccdb9b352a4db26ff419f7c49fa84.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/nixos/nixpkgs/archive/314e12ba369ccdb9b352a4db26ff419f7c49fa84.tar.gz"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1724316499,
+        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "northwood-nixpkgs": {
+      "inputs": {
+        "attic": "attic",
+        "disko": "disko",
+        "flake-compat": "flake-compat_2",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "sops-nix": "sops-nix"
+      },
+      "locked": {
+        "lastModified": 1743119614,
+        "narHash": "sha256-Rx176Jy8V0nplbZRPbmWAKjUoQlmB9B6+ww3/thd6Q4=",
+        "ref": "main",
+        "rev": "4388c8560e03ce7b45b74c49245a61d719a64fbe",
+        "revCount": 68,
+        "type": "git",
+        "url": "ssh://git@github.com/Northwood-Space/northwood-nixpkgs"
+      },
+      "original": {
+        "ref": "main",
+        "rev": "4388c8560e03ce7b45b74c49245a61d719a64fbe",
+        "type": "git",
+        "url": "ssh://git@github.com/Northwood-Space/northwood-nixpkgs"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "northwood-nixpkgs": "northwood-nixpkgs"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "northwood-nixpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742700801,
+        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    northwood-nixpkgs.url = "git+ssh://git@github.com/Northwood-Space/northwood-nixpkgs?ref=main&rev=4388c8560e03ce7b45b74c49245a61d719a64fbe";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, northwood-nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let pkgs = northwood-nixpkgs.legacyPackages.${system};
+        in {
+          devShells.default = import ./shell.nix {
+            inherit system pkgs;
+          };
+        }
+      );
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+# Display this default message
+default:
+	@just --list
+
+# Build BL31 and friends for stratix10 platform
+[group('Build')]
+build:
+	make -j$(nproc) $makeFlags
+
+# Build BL31 and friends for stratix10 platform
+[group('Build')]
+clean:
+	make clean
+	make distclean

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ default:
 build:
 	make -j$(nproc) $makeFlags
 
-# Build BL31 and friends for stratix10 platform
+# Don't be an animal, clean up after yourself
 [group('Build')]
 clean:
 	make clean

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,33 @@
+{ pkgs ? import <nixpkgs> {}
+, target ? "aarch64-multiplatform"
+, system
+}:
+let
+  # If we are aarch64-linux, then we do not need a cross-toolchain.
+  # Otherwise, grab the pkgsCross
+  #
+  # Notes on cross-compilation
+  # https://nixos.wiki/wiki/Cross_Compiling#Lazy_cross-compiling
+  # https://matthewbauer.us/blog/beginners-guide-to-cross.html
+  shouldCross = system == "aarch64-linux";
+  pkgsCross =
+    if shouldCross
+    then builtins.trace "using native pkgs" pkgs
+    else builtins.trace "using pkgsCross" pkgs.pkgsCross.${target};
+  # Even if we are cross-compiling we still want the pkg-config and friends for the machine we are building on, not building for.
+  pkgsBuild = pkgsCross.buildPackages;
+  # We want to use the same build environment that our nix derivation uses but with some new friends.
+  #
+  # This is why we choose to use overrideAttrs
+  # https://ryantm.github.io/nixpkgs/using/overrides/#sec-pkg-overrideAttrs
+  drv = pkgsCross.altera-arm-trusted-firmware.overrideAttrs(final: prev: {
+    # give it a new name so we can differentiate between nix build derivations and nix shell roots
+    pname = "northwood-arm-trusted-firmware";
+    nativeBuildInputs = builtins.concatLists [
+      # our build tools for
+      prev.nativeBuildInputs
+      # add our optional inputs
+    ];
+  });
+in
+drv


### PR DESCRIPTION
```bash
northwood@system76-pc ~/d/c/n/arm-trusted-firmware (devshell)> just
Available recipes:
    default # Display this default message

    [Build]
    build   # Build BL31 and friends for stratix10 platform
    clean   # Build BL31 and friends for stratix10 platform
northwood@system76-pc ~/d/c/n/arm-trusted-firmware (devshell)> nix develop .#
(nix:arm-trusted-firmware-aarch64-unknown-linux-gnu-env) northwood@system76-pc:~/development/cameron/northwood/arm-trusted-firmware$ just clean
make clean
  CLEAN
make distclean
  REALCLEAN
(nix:arm-trusted-firmware-aarch64-unknown-linux-gnu-env) northwood@system76-pc:~/development/cameron/northwood/arm-trusted-firmware$ just build
make -j$(nproc) $makeFlags
Building stratix10
  CC      bl2/aarch64/bl2_arch_setup.c
  CC      bl2/bl2_image_load_v2.c
  CC      bl2/bl2_main.c
  CC      common/bl_common.c
  CC      common/desc_image_load.c
  CC      common/tf_log.c
  CC      drivers/arm/gic/v2/gicdv2_helpers.c
  CC      drivers/arm/gic/v2/gicv2_helpers.c
  CC      drivers/arm/gic/v2/gicv2_main.c
  CC      drivers/console/multi_console.c
  CC      drivers/delay_timer/delay_timer.c
  CC      drivers/delay_timer/generic_delay_timer.c
  CC      drivers/intel/soc/stratix10/io/s10_memmap_qspi.c
  CC      drivers/io/io_block.c
  CC      drivers/io/io_fip.c
  CC      drivers/io/io_storage.c
  CC      drivers/mmc/mmc.c
  CC      drivers/partition/gpt.c
  CC      drivers/partition/partition.c
  CC      drivers/synopsys/emmc/dw_mmc.c
  CC      lib/compiler-rt/builtins/popcountdi2.c
  CC      lib/compiler-rt/builtins/popcountsi2.c
  CC      lib/extensions/pmuv3/aarch64/pmuv3.c
  CC      lib/xlat_tables/aarch64/xlat_tables.c
  CC      lib/xlat_tables/xlat_tables_common.c
  CC      lib/zlib/adler32.c
  CC      lib/zlib/crc32.c
  CC      lib/zlib/inffast.c
  CC      lib/zlib/inflate.c
  CC      lib/zlib/inftrees.c
  CC      lib/zlib/tf_gunzip.c
  CC      lib/zlib/zutil.c
  CC      plat/common/aarch64/plat_common.c
  CC      plat/common/plat_bl_common.c
  CC      plat/common/plat_gicv2.c
  CC      plat/common/plat_log_common.c
  CC      plat/intel/soc/common/aarch64/platform_common.c
  CC      plat/intel/soc/common/bl2_plat_mem_params_desc.c
  CC      plat/intel/soc/common/drivers/ccu/ncore_ccu.c
  CC      plat/intel/soc/common/drivers/ddr/ddr.c
  CC      plat/intel/soc/common/drivers/qspi/cadence_qspi.c
  CC      plat/intel/soc/common/drivers/wdt/watchdog.c
  CC      plat/intel/soc/common/soc/socfpga_emac.c
  CC      plat/intel/soc/common/soc/socfpga_firewall.c
  CC      plat/intel/soc/common/soc/socfpga_handoff.c
  CC      plat/intel/soc/common/soc/socfpga_mailbox.c
  CC      plat/intel/soc/common/soc/socfpga_reset_manager.c
  CC      plat/intel/soc/common/socfpga_delay_timer.c
  CC      plat/intel/soc/common/socfpga_image_load.c
  CC      plat/intel/soc/common/socfpga_storage.c
  CC      plat/intel/soc/stratix10/bl2_plat_setup.c
  CC      plat/intel/soc/stratix10/soc/s10_clock_manager.c
  CC      plat/intel/soc/stratix10/soc/s10_memory_controller.c
  CC      plat/intel/soc/stratix10/soc/s10_mmc.c
  CC      plat/intel/soc/stratix10/soc/s10_pinmux.c
  AS      bl2/aarch64/bl2_el3_entrypoint.S
  AS      bl2/aarch64/bl2_el3_exceptions.S
  AS      bl2/aarch64/bl2_run_next_image.S
  AS      common/aarch64/debug.S
  AS      common/aarch64/early_exceptions.S
  AS      drivers/ti/uart/aarch64/16550_console.S
  AS      lib/aarch64/cache_helpers.S
  AS      lib/aarch64/misc_helpers.S
  AS      lib/cpus/aarch64/cortex_a53.S
  AS      lib/cpus/aarch64/cpu_helpers.S
  AS      lib/cpus/aarch64/dsu_helpers.S
  AS      lib/locks/exclusive/aarch64/spinlock.S
  AS      plat/common/aarch64/platform_helpers.S
  AS      plat/common/aarch64/platform_up_stack.S
  AS      plat/intel/soc/common/aarch64/plat_helpers.S
  PP      bl2/bl2_el3.ld.S
  CC      lib/libc/memcpy.c
  CC      lib/libc/memcpy_s.c
  CC      lib/libc/memmove.c
  CC      lib/libc/memrchr.c
  CC      lib/libc/memset.c
  CC      lib/libc/printf.c
  CC      lib/libc/putchar.c
  CC      lib/libc/puts.c
  CC      lib/libc/snprintf.c
  CC      lib/libc/strchr.c
  CC      lib/libc/strcmp.c
  CC      lib/libc/strlcat.c
  CC      lib/libc/strlcpy.c
  CC      lib/libc/strlen.c
  CC      lib/libc/strncmp.c
  CC      lib/libc/strnlen.c
  CC      lib/libc/strrchr.c
  CC      lib/libc/strtok.c
  CC      lib/libc/strtoul.c
  CC      lib/libc/strtoll.c
  CC      lib/libc/strtoull.c
  CC      lib/libc/strtol.c
  AS      lib/libc/aarch64/setjmp.S
  CC      bl31/bl31_context_mgmt.c
  CC      bl31/bl31_main.c
  CC      bl31/bl31_traps.c
  CC      bl31/interrupt_mgmt.c
  CC      common/bl_common.c
  CC      common/runtime_svc.c
  CC      common/tf_log.c
  CC      drivers/arm/cci/cci.c
  CC      drivers/arm/gic/v2/gicdv2_helpers.c
  CC      drivers/arm/gic/v2/gicv2_helpers.c
  CC      drivers/arm/gic/v2/gicv2_main.c
  CC      drivers/console/multi_console.c
  CC      drivers/delay_timer/delay_timer.c
  CC      drivers/delay_timer/generic_delay_timer.c
  CC      lib/compiler-rt/builtins/popcountdi2.c
  CC      lib/compiler-rt/builtins/popcountsi2.c
  CC      lib/cpus/errata_report.c
  CC      lib/el3_runtime/aarch64/context_mgmt.c
  CC      lib/el3_runtime/cpu_data_array.c
  CC      lib/extensions/mpam/mpam.c
  CC      lib/extensions/pmuv3/aarch64/pmuv3.c
  CC      lib/extensions/spe/spe.c
  CC      lib/extensions/sve/sve.c
  CC      lib/locks/bakery/bakery_lock_coherent.c
  CC      lib/psci/psci_common.c
  CC      lib/psci/psci_main.c
  CC      lib/psci/psci_mem_protect.c
  CC      lib/psci/psci_off.c
  CC      lib/psci/psci_on.c
  CC      lib/psci/psci_setup.c
  CC      lib/psci/psci_suspend.c
  CC      lib/psci/psci_system_off.c
  CC      lib/xlat_tables/aarch64/xlat_tables.c
  CC      lib/xlat_tables/xlat_tables_common.c
  CC      plat/common/aarch64/plat_common.c
  CC      plat/common/plat_bl_common.c
  CC      plat/common/plat_gicv2.c
  CC      plat/common/plat_log_common.c
  CC      plat/common/plat_psci_common.c
  CC      plat/intel/soc/common/aarch64/platform_common.c
  CC      plat/intel/soc/common/drivers/ccu/ncore_ccu.c
  CC      plat/intel/soc/common/sip/socfpga_sip_ecc.c
  CC      plat/intel/soc/common/sip/socfpga_sip_fcs.c
  CC      plat/intel/soc/common/soc/socfpga_firewall.c
  CC      plat/intel/soc/common/soc/socfpga_mailbox.c
  CC      plat/intel/soc/common/soc/socfpga_reset_manager.c
  CC      plat/intel/soc/common/socfpga_delay_timer.c
  CC      plat/intel/soc/common/socfpga_psci.c
  CC      plat/intel/soc/common/socfpga_sip_svc.c
  CC      plat/intel/soc/common/socfpga_sip_svc_v2.c
  CC      plat/intel/soc/common/socfpga_topology.c
  CC      plat/intel/soc/stratix10/bl31_plat_setup.c
  CC      plat/intel/soc/stratix10/soc/s10_clock_manager.c
  CC      services/arm_arch_svc/arm_arch_svc_setup.c
  AS      bl31/aarch64/bl31_entrypoint.S
  CC      services/std_svc/std_svc_setup.c
  AS      bl31/aarch64/crash_reporting.S
  AS      bl31/aarch64/runtime_exceptions.S
  AS      common/aarch64/debug.S
  AS      drivers/ti/uart/aarch64/16550_console.S
  AS      lib/aarch64/cache_helpers.S
  AS      lib/aarch64/misc_helpers.S
  AS      lib/cpus/aarch64/aem_generic.S
  AS      lib/cpus/aarch64/cpu_helpers.S
  AS      lib/cpus/aarch64/cortex_a53.S
  AS      lib/cpus/aarch64/dsu_helpers.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_bpiall.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_mmu.S
  AS      lib/el3_runtime/aarch64/context.S
  AS      lib/el3_runtime/aarch64/cpu_data.S
  AS      lib/locks/exclusive/aarch64/spinlock.S
  AS      lib/psci/aarch64/psci_helpers.S
  AS      lib/psci/aarch64/runtime_errata.S
  AS      plat/common/aarch64/platform_helpers.S
  AS      plat/common/aarch64/platform_mp_stack.S
  AS      plat/intel/soc/common/aarch64/plat_helpers.S
  PP      bl31/bl31.ld.S
  AR      /home/northwood/development/cameron/northwood/arm-trusted-firmware/build/stratix10/release/lib/libc.a
  LD      /home/northwood/development/cameron/northwood/arm-trusted-firmware/build/stratix10/release/bl2/bl2.elf
  LD      /home/northwood/development/cameron/northwood/arm-trusted-firmware/build/stratix10/release/bl31/bl31.elf
  BIN     /home/northwood/development/cameron/northwood/arm-trusted-firmware/build/stratix10/release/bl2.bin
  OD      /home/northwood/development/cameron/northwood/arm-trusted-firmware/build/stratix10/release/bl2/bl2.dump

Built /home/northwood/development/cameron/northwood/arm-trusted-firmware/build/stratix10/release/bl2.bin successfully

  BIN     /home/northwood/development/cameron/northwood/arm-trusted-firmware/build/stratix10/release/bl31.bin
  OD      /home/northwood/development/cameron/northwood/arm-trusted-firmware/build/stratix10/release/bl31/bl31.dump

Built /home/northwood/development/cameron/northwood/arm-trusted-firmware/build/stratix10/release/bl31.bin successfully
```